### PR TITLE
Adding notes on communication differences to review culture document

### DIFF
--- a/culture/review_culture.md
+++ b/culture/review_culture.md
@@ -145,7 +145,17 @@ hurtful is not ok. If you feel offended by an interaction,
 it might be good to have an honest discussion with the other party involved and 
 talk about how the two of you can best communicate.
 
-## Best Practices for Reviewers
+# Best Practices
+
+## For Contributors
+
+### Prefer small changes
+
+### Document changes clearly
+
+### Self-review first
+
+## For Reviewers
 
 ### Be respectful and appreciative
 
@@ -153,6 +163,26 @@ As a reviewer, you should be respectful and appreciative towards the person
 proposing the change. This is true especially when you quite disagree with the
 change itself. It's fine to express strong beliefs that a change is misguided,
 but you shouldn't make the contributor feel belittled.
+
+### Consider "nit-and-approve"
+
+Some proposed changes look mostly good at a high level right off the bat,
+requiring only local, targeted suggestions. Consider approving such changes on
+your first review. You can still leave comments requesting changes from the
+author. This implies that the author of the change should feel free to merge
+the change once they've addressed your concerns. This is especially useful when
+the comments are uncontroversial, like typo fixes. The reviewer doesn't have to
+wait for you to take another look at the change and "officially" approve it
+before they can merge it and move on.
+
+Note that this requires a degree of trust. A reviewer should merge a change
+only once they believe in good faith that all comments really have been
+resolved, and that the author of each comment thread would not be surprised by
+how the feedback was received and incorporated. As a change author, it can be
+helpful for you to respond to all comments indicating how you addressed them.
+(In many cases, this is evident, and the comment can just say, "Done.") If you
+prefer not to incorporate some suggestion that wasn't intended to be optional,
+you should probably continue the discussion rather than merging immediately.
 
 ### Limit nit-picking
 
@@ -172,7 +202,9 @@ doing this, you should ask: in what ways is doing it my way materially better?
 What benefits come from the changed approach? If you don't have clear answers
 to these questions, don't ask for the change.
 
-### Take every measure to include contributors
+## For Maintainers
+
+### Include contributors even when closing their changes
 
 It could be the case that your thinking has changed since a review has started,
 and the change is no longer logical or necessary for the codebase. It might
@@ -195,23 +227,3 @@ longer being relevant. Instead of being turned off by the interaction, the contr
 is encouraged to be more deeply involved with the project. The same is true for a new contributor
 that might not have direction about how to help. A reviewer can ask questions or
 suggest ways to help to more directly engage the contributor.
-
-### Consider "nit-and-approve"
-
-Some proposed changes look mostly good at a high level right off the bat,
-requiring only local, targeted suggestions. Consider approving such changes on
-your first review. You can still leave comments requesting changes from the
-author. This implies that the author of the change should feel free to merge
-the change once they've addressed your concerns. This is especially useful when
-the comments are uncontroversial, like typo fixes. The reviewer doesn't have to
-wait for you to take another look at the change and "officially" approve it
-before they can merge it and move on.
-
-Note that this requires a degree of trust. A reviewer should merge a change
-only once they believe in good faith that all comments really have been
-resolved, and that the author of each comment thread would not be surprised by
-how the feedback was received and incorporated. As a change author, it can be
-helpful for you to respond to all comments indicating how you addressed them.
-(In many cases, this is evident, and the comment can just say, "Done.") If you
-prefer not to incorporate some suggestion that wasn't intended to be optional,
-you should probably continue the discussion rather than merging immediately.

--- a/culture/review_culture.md
+++ b/culture/review_culture.md
@@ -120,16 +120,41 @@ Some changes don't ever merge. A few good reasons why this may happen include:
 - Over the course of review, the contributor or reviewers may find a different
   and better way to achieve the same goals
 
-# Best Practices for Reviewers
+# Communication
 
-## Be respectful and appreciative
+## Be aware of culture
+
+It's easy to forget how common it is in open source communities to have diversity
+of geographic location, and different culture for communication. 
+As a new contributor to a community,  whether you take on a reviewer or a maintainer 
+role, your default expectation might be that others in the community will behave as you would. However, it's often the case that different cultures have different standards for
+communication. For example, in Western culture it's common to wrap criticism
+with a complement: 
+
+> "You did a really good job on X, _but_ I wonder if we could talk about your decision for using this data structure?" 
+
+Other cultures might be more straight forward to directly give more blunt feedback:
+
+> "The algorithm could be improved by this amount by using this data structure."
+ 
+If you are expecting differently, it can feel mean when it is not intended to. 
+Thus, while the community encourages open, and respectful communication, 
+it's good to keep in mind that this definition might vary depending on an individual's
+background and previous experience. Regardless, disrespect or communication that is
+hurtful is not ok, and if you feel offended by an interaction, 
+it might be good to have an honest discussion with the other party involved and 
+talk about how the two of you can best communicate.
+
+## Best Practices for Reviewers
+
+### Be respectful and appreciative
 
 As a reviewer, you should be respectful and appreciative towards the person
 proposing the change. This is true especially when you quite disagree with the
 change itself. It's fine to express strong beliefs that a change is misguided,
 but you shouldn't make the contributor feel belittled.
 
-## Limit nit-picking
+### Limit nit-picking
 
 Nit-picking is when a review focuses more on small, superficial details (e.g.
 precise formatting or word choice) rather than on the substance of the change.
@@ -138,7 +163,7 @@ tempting. It's ok to nit pick in moderation; when nit-picking, it's polite to
 preface your suggestion with "nit", as in: "nit: this comma should actually be
 a semicolon". Avoid holding up a review over nits.
 
-## Avoid "not how I would have done it"
+### Avoid "not how I would have done it"
 
 As a reviewer, you'll often notice that someone has made a change differently
 from how you would have made it. It can be tempting to think that your way is

--- a/culture/review_culture.md
+++ b/culture/review_culture.md
@@ -137,11 +137,11 @@ Other cultures might be more straight forward to directly give more blunt feedba
 
 > "The algorithm could be improved by this amount by using this data structure."
  
-If you are expecting differently, it can feel mean when it is not intended to. 
-Thus, while the community encourages open, and respectful communication, 
+If you are expecting differently, the critique can feel mean when it is not intended to. 
+Thus, while the community encourages open and respectful communication, 
 it's good to keep in mind that this definition might vary depending on an individual's
 background and previous experience. Regardless, disrespect or communication that is
-hurtful is not ok, and if you feel offended by an interaction, 
+hurtful is not ok. If you feel offended by an interaction, 
 it might be good to have an honest discussion with the other party involved and 
 talk about how the two of you can best communicate.
 
@@ -172,3 +172,26 @@ doing this, you should ask: in what ways is doing it my way materially better?
 What benefits come from the changed approach? If you don't have clear answers
 to these questions, don't ask for the change.
 
+### Take every measure to include contributors
+
+It could be the case that your thinking has changed since a review has started,
+and the change is no longer logical or necessary for the codebase. It might
+also be the case that an individual is new to contributing on a platform,
+and isn't quite sure how to best help. In both cases, as a maintainer you should
+take every measure to engage the contributors. For example, although this would
+be a respectful response:
+
+> Thank you for your contribution! We've decided to go in another direction, so unfortunately we will not be integrating the change.
+
+It ends the participation right away. Instead, you might consider
+a statement that delivers the same message, but further engages the contributor:
+
+> Thank you for your contribution! We've decided to go in another direction, and although we cannot use the changes here, would you be interested in working on [well-scoped task]?
+
+The more specific feedback or well scoped task that you are able to engage 
+the contributor with, the better. This kind of engagement sends the message
+that the contributor is valued and needed despite the particular review no
+longer being relevant. Instead of being turned off by the interaction, the contributor
+is encouraged to be more deeply involved with the project. The same is true for a new contributor
+that might not have direction about how to help. A reviewer can ask questions or
+suggest ways to help to more directly engage the contributor.


### PR DESCRIPTION
This is hard to articulate, but I think important to add (it's hit me several times in various open source communities, and it helps to have awareness for it). Basically:

 - people vary in how they communicate.
 - if expectations are not lined up (for example, I expect criticism wrapped in complements and an interaction is more straight forward) this can lead to hurt feelings or conflict
 - we have to encourage folks to be aware of the differences, so if a conflict arises, they can either realize "It's not me, this person just communicates more straight forward" or "This isn't how I want these interactions to go, I want to open a dialogue about it."

it's a hard thing to write up, because there isn't a single right way or suggestion to make for how to best communicate. But I do think entering most interactions with this awareness is helpful and important.

## Organization

As for organization, I changed the last section (which was originally just Best Practices for Reviewers) to be about Communication, and then the best practices is a subsection (because it does seem to be all about communication). At some future point someone could add a "Best Practices for Contributors" as well. Another organizational idea would be to have a general "Best Practices" section, separate from the "Communication" section, something like this:

- Communication
  - Be aware of culture
- Best Practices
  - Best Practices for Reviewers
  - Best Practices for Maintainers
  
The above would allow best practices to be included that are not directly communication related.
Signed-off-by: Vanessa Sochat <vsochat@stanford.edu>