### PR TITLE
Adding posts folder to render into "news" section of site, not included

### DIFF
--- a/_posts/2020-03-31-welcome.md
+++ b/_posts/2020-03-31-welcome.md
@@ -1,0 +1,37 @@
+---
+title:  "Welcome to the SourceCred Documentation!"
+date:   2020-03-31 09:52:21
+categories: jekyll update
+badges:
+ - type: info
+   tag: announce
+ - type: warning
+   tag: community
+---
+
+Welcome to the SourceCred Documentation base! This small feed of news is intended for
+announcements, changes, any any other news related to the docs. Now that you are here,
+let's give you some resources to be empowered to learn about Jekyll!
+
+<!--more-->
+
+If you want to add an announcement like this one, simply add a file in the `_posts` 
+directory that follows the convention `YYYY-MM-DD-name-of-post.md` 
+and includes the necessary front matter (copy paste it from the example here!). 
+Jekyll also offers powerful support for code snippets:
+
+{% highlight ruby %}
+def print_hi(name)
+  puts "Hi, #{name}"
+end
+print_hi('SourceCred')
+#=> prints 'Hi, SourceCred' to STDOUT.
+{% endhighlight %}
+
+Check out the [Jekyll docs][jekyll-docs] for more info on how to get the 
+most out of Jekyll. File all bugs/feature requests at [Jekyll’s GitHub repo][jekyll-gh]. 
+If you have questions, you can ask them on [Jekyll Talk][jekyll-talk].
+
+[jekyll-docs]: http://jekyllrb.com/docs/home
+[jekyll-gh]:   https://github.com/jekyll/jekyll
+[jekyll-talk]: https://talk.jekyllrb.com/


### PR DESCRIPTION
This is an artificially created PR to break #34 into pieces. This just includes the posts folder that renders into the site's news section.

Signed-off-by: vsoch <vsochat@stanford.edu>