### PR TITLE
Fix broken links and add Discord redirect

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -27,13 +27,13 @@ module.exports = {
           position: 'left',
         },
         {
-          to: 'docs/guides/FAQ',
+          to: 'docs/guides/earning-cred',
           activeBasePath: 'docs/guides',
           label: '🗺 Guides',
           position: 'left',
         },
         {
-          to: 'docs/setup/getting-started',
+          to: 'docs/setup/installation',
           activeBasePath: 'docs/setup',
           label: '🛠 Setup',
           position: 'left',

--- a/src/pages/discord.js
+++ b/src/pages/discord.js
@@ -1,11 +1,10 @@
 import React from 'react';
+import Head from '@docusaurus/Head';
 
-const Discord = () => {
-  React.useEffect(() => {
-    window.location.replace('https://discord.gg/SXreMyQ')
-  }, [])
-  
-  return null;
-};
+const Discord = () => (
+  <Head>
+    <meta httpEquiv="refresh" content="0; url=https://discord.gg/SXreMyQ" />
+  </Head>
+);
 
 export default Discord;

--- a/src/pages/discord.js
+++ b/src/pages/discord.js
@@ -1,0 +1,11 @@
+import React from 'react';
+
+const Discord = () => {
+  React.useEffect(() => {
+    window.location.replace('https://discord.gg/SXreMyQ')
+  }, [])
+  
+  return null;
+};
+
+export default Discord;


### PR DESCRIPTION
Closes #61

Fixed some mis-configured links in the navbar and added the Discord redirect back so people who visit sourcecred.io/discord will get sent to our Discord server