### PR TITLE
Update tagline

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -1,6 +1,6 @@
 module.exports = {
   title: 'SourceCred',
-  tagline: 'An open source community and reputation protocol for open collaboration.',
+  tagline: 'A tool for communities to measure and reward value creation.',
   url: 'https://sourcecred.github.io/docs',
   baseUrl: '/',
   favicon: 'img/favicon.png',


### PR DESCRIPTION
This changes the tagline from "An open source community and reputation protocol for open collaboration" to "A tool for communities to measure and reward value creation".

Paired with @Bex2594 @hammadj @burrrata and ben.oxmo#1365

Test plan: Use the docasaurus preview to check that the new tagline took.