### PR TITLE
Blog: Version 0.5.0 released

### DIFF
--- a/blog/2020-05-11-version-0.5.0-released.md
+++ b/blog/2020-05-11-version-0.5.0-released.md
@@ -1,0 +1,86 @@
+---
+id: version-0.5.0-released
+title: Version 0.5.0 released
+author: Beanow
+author_url: https://github.com/Beanow
+author_image_url: https://avatars3.githubusercontent.com/u/497556?v=4&s=200
+---
+
+It's been months since the last versioned release, so there's a lot new to
+v0.5.0!
+
+You can find the release [on GitHub][GitHub release] or as a [Docker image].
+More details on how to use them can be found in the [installation guide].
+
+Since this is a large release, I'll only touch on several major additions here.
+
+### Discourse plugin
+
+Discourse forums can be analyzed with this release. And from using it so far, I
+think it's a really interesting plugin.
+
+Discourse forums by default require no authentication to be set up. Meaning you
+can load most Discourse forums out there and explore them with SourceCred, no
+approval required. The [plugin setup guide][discourse setup] walks through the
+commands to do this.
+
+Much thanks to the straightforward 💚 likes on Discourse, the out-of-the-box
+settings tend to be quite reasonable. Most of the tweaking involves balancing
+the Discourse weight relative to other platforms.
+
+### Initiatives
+
+[Initiatives] are added to SourceCred by a new plugin of the same name.
+Instructions are in it's [setup guide][initiatives setup].
+
+While being technical to use in it's current version, it adds a number of new
+capabilities. Such as manually adding contributions for which there's no plugin,
+incentivizing work before it's completed and grouping contributions together to
+refer to them more easily.
+
+Since it's a recent addition, the jury is still out on whether we like the
+default settings and what the best ways to use it are. There's a good chance
+it will evolve as we test it out for ourselves and receive feedback from you.
+
+### Docker image
+
+As mentioned at the beginning of this post, SourceCred is being released as
+Docker images as well. They are available as [`sourcecred/sourcecred` on
+DockerHub][Docker image].
+
+The tags to be aware of are:
+- `latest` (default) which refers to the most recent versioned release.
+- `vX.X.X` versioned releases, which allow you to use a specific version.
+- `dev` which corresponds to the latest `master` branch.
+
+Even though this is the first major version to be included, the images are
+already seeing regular use by the community. Especially because it's a great way
+to set up automation for instances of SourceCred.
+
+### New data format: soucrecred output
+
+To support analyzing SourceCred's data further, we're exposing an additional
+JSON format.
+
+Previously we've had the "scores" format which exported the Cred scores of users
+and the "timeline cred" internal format which is not very easy to consume. With
+this format we're hoping to strike a balance, exposing more data than "scores"
+while also being comprehensive.
+
+Have a look at [the GitHub issue][sourcecred output issue] for more information.
+
+---
+
+That's all for now. Feel free to reach out to us with questions or issues.
+:telephone_receiver:
+- [GitHub](https://github.com/sourcecred/sourcecred)
+- [Discord](https://discord.gg/tsBTgc9)
+- [Discourse](https://discourse.sourcecred.io)
+
+[GitHub release]: https://github.com/sourcecred/sourcecred/releases/tag/v0.5.0
+[Docker image]: https://hub.docker.com/r/sourcecred/sourcecred/tags
+[installation guide]: ../docs/setup/installation
+[discourse setup]: ../docs/setup/plugins/discourse
+[Initiatives]: ../docs/concepts/initiatives
+[initiatives setup]: ../docs/setup/plugins/initiatives
+[sourcecred output issue]: https://github.com/sourcecred/sourcecred/issues/1773

--- a/blog/2020-05-11-version-0.5.0-released.md
+++ b/blog/2020-05-11-version-0.5.0-released.md
@@ -17,31 +17,44 @@ here.
 
 ### Discourse plugin
 
-Discourse forums can be analyzed with this release. And from using it so far, we
-think it's a really interesting plugin.
+As of this release, you can use SourceCred to analyze [Discourse] forums
+(for example, SourceCred's [own forum]). Our experience so far is that it's
+one of the most interesting plugins, and it works well out of the box!
 
-Discourse forums by default require no authentication to be set up. Meaning you
-can load most Discourse forums out there and explore them with SourceCred, no
-approval required. The [plugin setup guide][discourse setup] walks through the
-commands to do this.
+The basic logic of the Discourse plugin is that every topic, post, and like
+on the forums can flow cred, with cred accumulating at posts that received
+lots of likes, or lots of high-cred responses. Cred also flows between posts
+that reference each other. And the users that authored high cred posts wind up
+with plenty of cred themselves.
 
-Much thanks to the straightforward 💚 likes on Discourse, the out-of-the-box
-settings tend to be quite reasonable. Most of the tweaking involves balancing
-the Discourse weight relative to other platforms.
+The plugin doesn't require any special credentials, so you can easily explore
+Discourse forums you're curious about using SourceCred. It can give a
+perspective on which people are adding content most valued by the community.
+The [plugin setup guide][discourse setup] walks through the commands to do
+this.
 
 ### Initiatives
 
 [Initiatives] are added to SourceCred by a new plugin of the same name.
 Instructions are in its [setup guide][initiatives setup].
 
-While being technical to use in its current version, it adds a number of new
-capabilities. Example of capabilities we'd like to look into are adding
-contributions for which there's no plugin, incentivizing work before it's
-completed and grouping contributions together to value them more easily.
+The goal of the initiatives plugin is to allow tracking important work that
+wasn't directly captured on existing platforms like GitHub or Discourse. You
+can think of the initiatives plugin as being a "manual mode" way to tune the
+contribution graph. Within SourceCred itself, we're using initiatives to track
+work like organizing community calls, championing higher-level features, or
+supporting our partner projects.
 
-Since it's a recent addition, the jury is still out on whether we like the
-default settings and what the best ways to use it are. There's a good chance
-it will evolve as we test it out for ourselves and receive feedback from you.
+The plugin is still in an early form--consider it an alpha-level feature.
+Currently, adding initiatives requires manually tweaking json files on GitHub,
+but we're hoping to make this more intuitive and accessible by adding a UI in
+the near future.
+
+If you want to learn more about the rationale for adding initiatives, you
+can read
+[this forum post](https://discourse.sourcecred.io/t/supernodes-moving-past-raw-activity/340)
+which discusses some of the limitations of tracking cred at the level of raw
+activity, like pull requests or posts.
 
 ### Docker image
 
@@ -58,7 +71,7 @@ Even though this is the first major version to be included, the images are
 already seeing regular use by the community, especially because it's a great way
 to set up automation for instances of SourceCred.
 
-### New data format: soucrecred output
+### New data format: `soucrecred output`
 
 To support analyzing SourceCred's data further, we're exposing an additional
 JSON format.
@@ -78,6 +91,8 @@ That's all for now. Feel free to reach out to us with questions or issues.
 - [Discord](https://discord.gg/tsBTgc9)
 - [Discourse](https://discourse.sourcecred.io)
 
+[Discourse]: https://www.discourse.org/
+[own forum]: https://discourse.sourcecred.io
 [GitHub release]: https://github.com/sourcecred/sourcecred/releases/tag/v0.5.0
 [Docker image]: https://hub.docker.com/r/sourcecred/sourcecred/tags
 [installation guide]: ../docs/setup/installation

--- a/blog/2020-05-11-version-0.5.0-released.md
+++ b/blog/2020-05-11-version-0.5.0-released.md
@@ -46,9 +46,10 @@ work like organizing community calls, championing higher-level features, or
 supporting our partner projects.
 
 The plugin is still in an early form, consider it an alpha-level feature.
-Currently, adding Initiatives requires manually tweaking JSON files on GitHub,
-but we're hoping to make this more intuitive and accessible by adding a UI in
-the near future.
+While adding Initiatives currently is fairly technical and requires manually
+tweaking JSON files on GitHub, it does add new capabilities to explore. We're
+hoping to improve this as we test it out ourselves and receive feedback from
+you.
 
 If you want to learn more about the rationale for adding Initiatives, you
 can read [Supernodes: Moving past raw activity] which discusses some of the

--- a/blog/2020-05-11-version-0.5.0-released.md
+++ b/blog/2020-05-11-version-0.5.0-released.md
@@ -34,9 +34,9 @@ the Discourse weight relative to other platforms.
 Instructions are in its [setup guide][initiatives setup].
 
 While being technical to use in its current version, it adds a number of new
-capabilities. Such as manually adding contributions for which there's no plugin,
-incentivizing work before it's completed and grouping contributions together to
-refer to them more easily.
+capabilities. Example of capabilities I'd like to look into are adding
+contributions for which there's no plugin, incentivizing work before it's
+completed and grouping contributions together to value them more easily.
 
 Since it's a recent addition, the jury is still out on whether we like the
 default settings and what the best ways to use it are. There's a good chance
@@ -54,7 +54,7 @@ The tags to be aware of are:
 - `dev` which corresponds to the latest `master` branch.
 
 Even though this is the first major version to be included, the images are
-already seeing regular use by the community. Especially because it's a great way
+already seeing regular use by the community, especially because it's a great way
 to set up automation for instances of SourceCred.
 
 ### New data format: soucrecred output

--- a/blog/2020-05-11-version-0.5.0-released.md
+++ b/blog/2020-05-11-version-0.5.0-released.md
@@ -1,9 +1,9 @@
 ---
 id: version-0.5.0-released
 title: Version 0.5.0 released
-author: Beanow
-author_url: https://github.com/Beanow
-author_image_url: https://avatars3.githubusercontent.com/u/497556?v=4&s=200
+author: SourceCred
+author_url: https://github.com/sourcecred
+author_image_url: https://avatars3.githubusercontent.com/u/35711667?s=200&v=4
 ---
 
 It's been months since the last versioned release, so there's a lot new to
@@ -12,11 +12,12 @@ v0.5.0!
 You can find the release [on GitHub][GitHub release] or as a [Docker image].
 More details on how to use them can be found in the [installation guide].
 
-Since this is a large release, I'll only touch on several major additions here.
+Since this is a large release, this post only touches on several major additions
+here.
 
 ### Discourse plugin
 
-Discourse forums can be analyzed with this release. And from using it so far, I
+Discourse forums can be analyzed with this release. And from using it so far, we
 think it's a really interesting plugin.
 
 Discourse forums by default require no authentication to be set up. Meaning you
@@ -34,7 +35,7 @@ the Discourse weight relative to other platforms.
 Instructions are in its [setup guide][initiatives setup].
 
 While being technical to use in its current version, it adds a number of new
-capabilities. Example of capabilities I'd like to look into are adding
+capabilities. Example of capabilities we'd like to look into are adding
 contributions for which there's no plugin, incentivizing work before it's
 completed and grouping contributions together to value them more easily.
 

--- a/blog/2020-05-11-version-0.5.0-released.md
+++ b/blog/2020-05-11-version-0.5.0-released.md
@@ -22,10 +22,10 @@ As of this release, you can use SourceCred to analyze [Discourse] forums
 one of the most interesting plugins, and it works well out of the box!
 
 The basic logic of the Discourse plugin is that every topic, post, and like
-on the forums can flow cred, with cred accumulating at posts that received
-lots of likes, or lots of high-cred responses. Cred also flows between posts
-that reference each other. And the users that authored high cred posts wind up
-with plenty of cred themselves.
+on the forums can flow Cred, with Cred accumulating at posts that received
+lots of likes, or lots of high Cred responses. Cred also flows between posts
+that reference each other. And the users that authored high Cred posts wind up
+with plenty of Cred themselves.
 
 The plugin doesn't require any special credentials, so you can easily explore
 Discourse forums you're curious about using SourceCred. It can give a
@@ -38,23 +38,22 @@ this.
 [Initiatives] are added to SourceCred by a new plugin of the same name.
 Instructions are in its [setup guide][initiatives setup].
 
-The goal of the initiatives plugin is to allow tracking important work that
+The goal of the Initiatives plugin is to allow tracking important work that
 wasn't directly captured on existing platforms like GitHub or Discourse. You
-can think of the initiatives plugin as being a "manual mode" way to tune the
-contribution graph. Within SourceCred itself, we're using initiatives to track
+can think of the Initiatives plugin as being a "manual mode" way to tune the
+contribution graph. Within SourceCred itself, we're using Initiatives to track
 work like organizing community calls, championing higher-level features, or
 supporting our partner projects.
 
-The plugin is still in an early form--consider it an alpha-level feature.
-Currently, adding initiatives requires manually tweaking json files on GitHub,
+The plugin is still in an early form, consider it an alpha-level feature.
+Currently, adding Initiatives requires manually tweaking JSON files on GitHub,
 but we're hoping to make this more intuitive and accessible by adding a UI in
 the near future.
 
-If you want to learn more about the rationale for adding initiatives, you
-can read
-[this forum post](https://discourse.sourcecred.io/t/supernodes-moving-past-raw-activity/340)
-which discusses some of the limitations of tracking cred at the level of raw
-activity, like pull requests or posts.
+If you want to learn more about the rationale for adding Initiatives, you
+can read [Supernodes: Moving past raw activity] which discusses some of the
+limitations of tracking Cred at the level of raw activity, like pull requests or
+posts.
 
 ### Docker image
 
@@ -100,3 +99,4 @@ That's all for now. Feel free to reach out to us with questions or issues.
 [Initiatives]: ../docs/concepts/initiatives
 [initiatives setup]: ../docs/setup/plugins/initiatives
 [sourcecred output issue]: https://github.com/sourcecred/sourcecred/issues/1773
+[Supernodes: Moving past raw activity]: https://discourse.sourcecred.io/t/supernodes-moving-past-raw-activity/340

--- a/blog/2020-05-11-version-0.5.0-released.md
+++ b/blog/2020-05-11-version-0.5.0-released.md
@@ -31,9 +31,9 @@ the Discourse weight relative to other platforms.
 ### Initiatives
 
 [Initiatives] are added to SourceCred by a new plugin of the same name.
-Instructions are in it's [setup guide][initiatives setup].
+Instructions are in its [setup guide][initiatives setup].
 
-While being technical to use in it's current version, it adds a number of new
+While being technical to use in its current version, it adds a number of new
 capabilities. Such as manually adding contributions for which there's no plugin,
 incentivizing work before it's completed and grouping contributions together to
 refer to them more easily.


### PR DESCRIPTION
Depends on: #71
Fixes: #73 

Taking a stab at blogging about the v0.5.0 release: https://github.com/sourcecred/sourcecred/issues/1679.

I've written this in a more personal rather than neutral tone. As that means opinions included, I've not used "SourceCred" as the author but put this under my own name.

The release notes here: https://github.com/sourcecred/sourcecred/releases/tag/v0.5.0
Are what I would likely have copied if asked for a more neutral SourceCred message.

What do you think of this approach, like the personal notes? Think we should have an official SourceCred post instead? _Let me know in the comments below, hit like and subscribe, find me on Patreon, buy a mug from the store, etc. you know how it works._