### PR TITLE
Update Discord invite link

### DIFF
--- a/blog/2020-05-11-version-0.5.0-released.md
+++ b/blog/2020-05-11-version-0.5.0-released.md
@@ -88,7 +88,7 @@ Have a look at [the GitHub issue][sourcecred output issue] for more information.
 That's all for now. Feel free to reach out to us with questions or issues.
 :telephone_receiver:
 - [GitHub](https://github.com/sourcecred/sourcecred)
-- [Discord](https://discord.gg/tsBTgc9)
+- [Discord](https://sourcecred.io/discord)
 - [Discourse](https://discourse.sourcecred.io)
 
 [Discourse]: https://www.discourse.org/

--- a/docs/contributing/get-an-ambassador.md
+++ b/docs/contributing/get-an-ambassador.md
@@ -12,7 +12,7 @@ An Ambassador relationship usually spans the first couple of weeks to make sure 
 
 Before requesting an Ambassador, you should have moved through the first few steps of engaging with our community outlined in the [How to Get Involved guide](get-involved.md). Including:
 
-- Joining the SourceCred Discord
+- Joining the [SourceCred Discord](https://sourcecred.io/discord)
 - Reading up on the available documentation
 - Introducing yourself on Discord
 - Coming to a Community Call

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -64,7 +64,7 @@ module.exports = {
           items: [
             {
               label: "Chat",
-              href: "https://discord.gg/SXreMyQ"
+              href: "https://sourcecred.io/discord"
             },
             {
               label: "Forums",

--- a/src/pages/discord.js
+++ b/src/pages/discord.js
@@ -3,8 +3,9 @@ import Head from '@docusaurus/Head';
 
 const Discord = () => (
   <Head>
-    <meta httpEquiv="refresh" content="0; url=https://discord.gg/SXreMyQ" />
+    <meta httpEquiv="refresh" content="0; url=https://discord.gg/q9tDN7p" />
   </Head>
 );
 
 export default Discord;
+


### PR DESCRIPTION
This updates the Discord invite link so that it now drops people in the
start-here channel rather than the general channel. I've also updated
existing hardcoded references to old invites to all point to the
redirect, so that we can continue to update invite links in the future.

Possible TODO: if we find that the redirect adds an extra annoying step
for the user, we could always make a variable for the discord invite and
depend on it via code. But for now I think this is fine.

Test plan: In the CI preview, test out `https://sourcecred.io/discord`.