### PR TITLE
Replace "Get An Ambassador" section with "Attend a Jam"

### DIFF
--- a/docs/contributing/get-involved.md
+++ b/docs/contributing/get-involved.md
@@ -6,19 +6,19 @@ Follow the steps below to get connected with the SourceCred community.
 
 ## 1. Join the SourceCred Discord
 
-The very first step for getting involved with our community is to join our community discussions. [Discord](https://discord.com/) is the platform we use to be social and talk not only about our projects and goals, but also to get to know one another and build a sense of connection in real time.
+The very first step for getting involved with our community is to join our community discussions. Discord is the platform we use to be social and talk not only about our projects and goals, but also to get to know one another and build a sense of connection in real time.
 
-### Step 1: Create a Discord Account
+Step 1: Create a Discord Account
 
-If you have never used Discord before, you’ll want to download the application (or access it via web browser) and create your own account with their service.
+If you have never used [Discord](https://discord.com/) before, you’ll want to download the application (or access it via web browser) and create your own account with their service.
 
-### Step 2: Join SourceCred’s Community Discord Server
+Step 2: Join SourceCred’s Community Discord Server
 
 Discord is a service, and SourceCred has it’s own server where you can join the conversation. Once you've got your Discord account, you can join the SourceCred server with [this invite](https://sourcecred.io/discord).
 
 ## 2. Poke Through Our Resources
 
-Explore this website, the #signpost channel in Discord, and, if you're feeling adventurous, our [Discourse forums](https://discourse.sourcecred.io).
+Explore this website, the #start-here channel in Discord, and, if you're feeling adventurous, our [Discourse forums](https://discourse.sourcecred.io).
 
 ## 3. Introduce Yourself
 
@@ -38,13 +38,10 @@ The SourceCred Community Call is a weekly voice call which we encourage anyone i
 
 We encourage you to attend one and see how you like our community. We also would love it if you brought a question or two with you about things you’d like to understand better within SourceCred. That way, not only do you get a chance to learn but others on the call will have the chance as well!
 
-The Community Call is every Tuesday at 11am PT (double check your time zone) in the “General” voice channel on our Discord.
-You can add it to your Google Calendar using [this invite link](https://calendar.google.com/event?action=TEMPLATE&tmeid=MTVsc3ZiczVpc3AyOWYya2VmYmUxaWhnZXBfMjAyMDA1MTlUMTgwMDAwWiBvcHNAc291cmNlY3JlZC5pbw&tmsrc=ops%40sourcecred.io&scp=ALL).
+The Community Call is every Tuesday at 11am PT (double check your time zone) in the “Main” voice channel on our Discord.
+Check out our [SourceCred Calendar](https://calendar.google.com/calendar/b/1?cid=b3BzQHNvdXJjZWNyZWQuaW8) and find a Tuesday that works for you. We'd love to have you!
 
-## 5. Get an Ambassador
+## 5. Attend a "Jam"
 
-Once you’ve decided that you like the SourceCred community, and that you’d really like to get involved bringing your own unique perspective and skills to the benefit of the project, you’re ready for an Ambassador. Ambassadors help to guide newcomers on their path to becoming full contributors in the project and will provide you with support and resources on your journey.
+A "Jam" is a scheduled time to discuss a particular topic in SourceCred on the Discord voice channel. This is a time to dive deeper into specific topics like crypto-economics, our mission and values, or community cultivation with the community and is a great opportunity for anyone to join the conversation. Check out the [SourceCred Calendar](https://calendar.google.com/calendar/b/1?cid=b3BzQHNvdXJjZWNyZWQuaW8) to see if there's an upcoming jam with a topic that interests you! It's the best way to get familiar with the lay of the land and start exploring where you may be able to contribute.
 
-If you’re not quite ready to dig your hands in and start contributing, that’s okay. Feel free to keep chatting on the Discord, reading the documentation, and coming to the Community Calls. Once you feel like you want to get more involved and start contributing, our Ambassadors will be here for you.
-
-You can find more step by step info for requesting your own Ambassador [here](https://discourse.sourcecred.io/t/how-to-get-an-ambassador/727).


### PR DESCRIPTION
Our thinking around Ambassadorship is changing, so I've replaced section 5 of this doc which explains how to get an ambassador for yourself with information about how to attend the "Jams" we've started doing. 
I also updated a few channel names that have changed in our Discord.