### PR TITLE
Enable darkmode by default

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -7,6 +7,7 @@ module.exports = {
   organizationName: 'sourcecred', // Usually your GitHub org/user name.
   projectName: 'docs', // Usually your repo name.
   themeConfig: {
+    defaultDarkMode: true,
     navbar: {
       title: 'SourceCred',
       logo: {


### PR DESCRIPTION
This ensures that the website has darkmode enabled by default, which is more on-brand for SC.

Merging this into the branch for updating Docusaurus (PR #96) since the current version we have doesn't have this feature.