### PR TITLE
Setup Netlify CMS

### DIFF
--- a/blog/2020-04-08-coming-soon.md
+++ b/blog/2020-04-08-coming-soon.md
@@ -1,9 +1,0 @@
----
-id: coming-soon
-title: Coming Soon
-author: SourceCred
-author_url: https://github.com/sourcecred
-author_image_url: https://avatars3.githubusercontent.com/u/35711667?s=200&v=4
----
-
-SourceCred blog coming soon!

--- a/blog/2020-05-11-version-0.5.0-released.md
+++ b/blog/2020-05-11-version-0.5.0-released.md
@@ -1,6 +1,6 @@
 ---
-id: version-0.5.0-released
 title: Version 0.5.0 released
+description: See what's new in SourceCred v0.5.0
 author: SourceCred
 author_url: https://github.com/sourcecred
 author_image_url: https://avatars3.githubusercontent.com/u/35711667?s=200&v=4

--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -19,7 +19,6 @@ collections:
       - {label: "Publish Date", name: "date", widget: "datetime"}
       - {label: "Description", name: "description", widget: "string", required: false, hint: "The description of the post which will be used by search engines and link previews. If not present, will default to the first line of the post contents."}
       - {label: "Cover Image",name: "image", widget: "image", required: false,  hint: "Cover or thumbnail image that will be used when displaying the link to the post."}
-      - {label: "Draft",name: "draft", widget: "boolean", required: false,  hint: "Prevent the post from being published, but still allows it to be displayed during development."}
       - {label: "Author", name: "author", widget: "string", default: "SourceCred", hint: "The author name to be displayed"}
       - {label: "Author URL", name: "author_url", widget: "string", required: false, default: "https://twitter.com/sourcecred", hint: "The URL that the author's name will be linked to."}
       - {label: "Author Image", name: "author_image_url", widget: "image", required: false, default: "https://avatars3.githubusercontent.com/u/35711667?s=200&v=4", hint: "The author's thumbnail image."}

--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -1,0 +1,26 @@
+backend:
+  name: github
+  repo: sourcecred/docs
+  branch: master
+  open_authoring: true # enables users without write access to author content from their forks
+publish_mode: editorial_workflow
+media_folder: "static/img/uploads"
+public_folder: "img/uploads"
+display_url: https://sourcecred.io # Displayed in header of CMS UI
+collections:
+  - name: "blog" # Used in routes, e.g., /admin/collections/blog
+    label: "Blog" # Used in the UI
+    folder: "blog" # The path to the folder where the documents are stored
+    create: true # Allow users to create new documents in this collection
+    slug: "{{year}}-{{month}}-{{day}}-{{slug}}" # Filename template, e.g., YYYY-MM-DD-title.md
+    preview_path: "blog/{{slug}}" # Ensures Deploy previews in PRs link to the newly added doc
+    fields: # The fields for each document, usually in front matter
+      - {label: "Title", name: "title", widget: "string"}
+      - {label: "Publish Date", name: "date", widget: "datetime"}
+      - {label: "Description", name: "description", widget: "string", required: false, hint: "The description of the post which will be used by search engines and link previews. If not present, will default to the first line of the post contents."}
+      - {label: "Cover Image",name: "image", widget: "image", required: false,  hint: "Cover or thumbnail image that will be used when displaying the link to the post."}
+      - {label: "Draft",name: "draft", widget: "boolean", required: false,  hint: "Prevent the post from being published, but still allows it to be displayed during development."}
+      - {label: "Author", name: "author", widget: "string", default: "SourceCred", hint: "The author name to be displayed"}
+      - {label: "Author URL", name: "author_url", widget: "string", required: false, default: "https://twitter.com/sourcecred", hint: "The URL that the author's name will be linked to."}
+      - {label: "Author Image", name: "author_image_url", widget: "image", required: false, default: "https://avatars3.githubusercontent.com/u/35711667?s=200&v=4", hint: "The author's thumbnail image."}
+      - {label: "Body", name: "body", widget: "markdown", buttons:}

--- a/static/admin/index.html
+++ b/static/admin/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html>
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Content Manager</title>
+</head>
+<body>
+<!-- Include the script that builds the page and powers Netlify CMS -->
+<script src="https://unpkg.com/netlify-cms@^2.0.0/dist/netlify-cms.js"></script>
+</body>
+</html>


### PR DESCRIPTION
This configures Netlify CMS to allow people to create and edit pages in our docs repo without having to know how to use git. Right now its only setup for blog posts just to see if we can get it working properly.

### Details

- The config can be found in `static/admin/config.yml`, more info on available options can be found [here](https://www.netlifycms.org/docs/configuration-options/).
- You can access the admin UI by appending `/admin` to the URL. [Deploy preview of the Admin UI](https://deploy-preview-98--priceless-morse-4119fb.netlify.app/admin)
- The reason its going to be a bit trickier for docs is the sidebars.js file that specifies what pages are visible and in what order in the side navigation. One solution to this would be to have a script that can autogenerate the sidebars.js file before the build step, or use something like [this](https://github.com/acrobit/docusaurus-plugin-auto-sidebars).

**Test Plan:** Go to the /admin page on the deployed site to see if it renders the NetlifyCMS UI correctly, displays the existing blog posts, and allows creating new ones