### PR TITLE
Setup Editor Interface for Docs Pages

### DIFF
--- a/docs/intro/resources.md
+++ b/docs/intro/resources.md
@@ -3,4 +3,13 @@ title: 🌳 Resources
 description:
 ---
 
-Check out our [media page](../resources/media)
+## Videos
+
+- [SourceCred at the Open 2020 Webinar](https://www.youtube.com/watch?v=tGRcPW3LXmU)
+- [SourceCred and the CredSperiment at Ready Layer One](https://www.youtube.com/watch?v=38OlnEPpzeo)
+- [SourceCred: A Social Algorithm at Sustain Web3 2020](https://www.youtube.com/watch?v=EME4CZscPB8)
+- [SourceCred at the Berlin Open Source Salon](https://www.youtube.com/watch?v=fK0vjRq-4oI&t=1s)
+- [SourceCred at Lab Day 2018](https://www.youtube.com/watch?v=qEIHmKPMpYE)
+
+## Podcast
+- [SourceCred Podcast](https://sourcecred.podbean.com/)

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -104,7 +104,7 @@ module.exports = {
         docs: {
           sidebarPath: require.resolve('./sidebars.js'),
           editUrl:
-            'https://github.com/sourcecred/docs/edit/master/',
+            'https://sourcecred.io/admin/#/?',
         },
         theme: {
           customCss: require.resolve('./src/css/custom.css'),

--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -6,7 +6,8 @@ backend:
 publish_mode: editorial_workflow
 media_folder: "static/img/uploads"
 public_folder: "img/uploads"
-display_url: https://sourcecred.io # Displayed in header of CMS UI
+site_url: https://sourcecred.io
+logo_url: https://sourcecred.io/img/favicon.png
 collections:
   - name: "blog" # Used in routes, e.g., /admin/collections/blog
     label: "Blog" # Used in the UI
@@ -14,6 +15,8 @@ collections:
     create: true # Allow users to create new documents in this collection
     slug: "{{year}}-{{month}}-{{day}}-{{slug}}" # Filename template, e.g., YYYY-MM-DD-title.md
     preview_path: "blog/{{slug}}" # Ensures Deploy previews in PRs link to the newly added doc
+    editor:
+      preview: false
     fields: # The fields for each document, usually in front matter
       - {label: "Title", name: "title", widget: "string"}
       - {label: "Publish Date", name: "date", widget: "datetime"}
@@ -22,4 +25,82 @@ collections:
       - {label: "Author", name: "author", widget: "string", default: "SourceCred", hint: "The author name to be displayed"}
       - {label: "Author URL", name: "author_url", widget: "string", required: false, default: "https://twitter.com/sourcecred", hint: "The URL that the author's name will be linked to."}
       - {label: "Author Image", name: "author_image_url", widget: "image", required: false, default: "https://avatars3.githubusercontent.com/u/35711667?s=200&v=4", hint: "The author's thumbnail image."}
-      - {label: "Body", name: "body", widget: "markdown", buttons:}
+      - {label: "Body", name: "body", widget: "markdown"}
+  - name: "intro"
+    label: "Introduction"
+    folder: "docs/intro"
+    create: true
+    slug: "{{slug}}"
+    preview_path: "docs/intro/{{slug}}"
+    editor:
+      preview: false
+    fields:
+      - {label: "Title", name: "title", widget: "string"}
+      - {label: "Description", name: "description", widget: "string", required: false, hint: "The description of the post which will be used by search engines and link previews. If not present, will default to the first line of the post contents."}
+      - {label: "Cover Image",name: "image", widget: "image", required: false,  hint: "Cover or thumbnail image that will be used when displaying the link to the post."}
+      - {label: "Body", name: "body", widget: "markdown"}
+  - name: "concepts"
+    label: "Concepts"
+    folder: "docs/concepts"
+    create: true
+    slug: "{{slug}}"
+    preview_path: "docs/concepts/{{slug}}"
+    editor:
+      preview: false
+    fields:
+      - {label: "Title", name: "title", widget: "string"}
+      - {label: "Description", name: "description", widget: "string", required: false, hint: "The description of the post which will be used by search engines and link previews. If not present, will default to the first line of the post contents."}
+      - {label: "Cover Image",name: "image", widget: "image", required: false,  hint: "Cover or thumbnail image that will be used when displaying the link to the post."}
+      - {label: "Body", name: "body", widget: "markdown"}
+  - name: "guides"
+    label: "Guides"
+    folder: "docs/guides"
+    create: true
+    slug: "{{slug}}"
+    preview_path: "docs/guides/{{slug}}"
+    editor:
+      preview: false
+    fields:
+      - {label: "Title", name: "title", widget: "string"}
+      - {label: "Description", name: "description", widget: "string", required: false, hint: "The description of the post which will be used by search engines and link previews. If not present, will default to the first line of the post contents."}
+      - {label: "Cover Image",name: "image", widget: "image", required: false,  hint: "Cover or thumbnail image that will be used when displaying the link to the post."}
+      - {label: "Body", name: "body", widget: "markdown"}
+  - name: "guides-platforms"
+    label: "Guides > Platforms"
+    folder: "docs/guides/platforms"
+    create: true
+    slug: "{{slug}}"
+    preview_path: "docs/guides/platforms/{{slug}}"
+    editor:
+      preview: false
+    fields:
+      - {label: "Title", name: "title", widget: "string"}
+      - {label: "Description", name: "description", widget: "string", required: false, hint: "The description of the post which will be used by search engines and link previews. If not present, will default to the first line of the post contents."}
+      - {label: "Cover Image",name: "image", widget: "image", required: false,  hint: "Cover or thumbnail image that will be used when displaying the link to the post."}
+      - {label: "Body", name: "body", widget: "markdown"}
+  - name: "setup"
+    label: "Setup and Usage"
+    folder: "docs/setup"
+    create: true
+    slug: "{{slug}}"
+    preview_path: "docs/setup/{{slug}}"
+    editor:
+      preview: false
+    fields:
+      - {label: "Title", name: "title", widget: "string"}
+      - {label: "Description", name: "description", widget: "string", required: false, hint: "The description of the post which will be used by search engines and link previews. If not present, will default to the first line of the post contents."}
+      - {label: "Cover Image",name: "image", widget: "image", required: false,  hint: "Cover or thumbnail image that will be used when displaying the link to the post."}
+      - {label: "Body", name: "body", widget: "markdown"}
+  - name: "setup-plugins"
+    label: "Setup and Usage > Plugins"
+    folder: "docs/setup/plugins"
+    create: true
+    slug: "{{slug}}"
+    preview_path: "docs/setup/plugins/{{slug}}"
+    editor:
+      preview: false
+    fields:
+      - {label: "Title", name: "title", widget: "string"}
+      - {label: "Description", name: "description", widget: "string", required: false, hint: "The description of the post which will be used by search engines and link previews. If not present, will default to the first line of the post contents."}
+      - {label: "Cover Image",name: "image", widget: "image", required: false,  hint: "Cover or thumbnail image that will be used when displaying the link to the post."}
+      - {label: "Body", name: "body", widget: "markdown"}


### PR DESCRIPTION
This will allow us to write/edit docs pages through a visual CMS accessible at [sourcecred.io/admin](https://sourcecred.io/admin). One shortcoming right now is the inability to edit the sidebar from the CMS interface, that will require some custom code / widgets to link the files and generate the correct JSON format. For now, we can just edit the sidebar in code as needed. A lot of the docs have placeholder TODO files, so it shouldn't be too big of a deal. 

Test Plan: Go to the admin page and see if all the current docs are visible there and that creating a new doc in a certain section creates the file in the correct folder.