### PR TITLE
Fixup comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,8 +64,8 @@ This command generates static content into the `build` directory and can be serv
 
 At this point you can edit pages in [pages](pages) or [docs](docs) and add new pages
 as you see fit. See the [development](#development) section for how to update the table of
-contents or navigation, and [open an issue](https://github.com/sourcecred/docs/issues) 
-if you need some help! 
+contents or navigation, and [open an issue](https://github.com/sourcecred/docs/issues)
+if you need some help!
 
 #### Making a New Documentation Page
 
@@ -157,4 +157,11 @@ Once you've made changes on your new branch, open a new pull request to have the
 reviewed! When they are merged to master they will go live on the site.
 
 
+#### A Note On Comments
+
+You can add a comment to a page using the following syntax:
+
+```
+[//]: # (THIS IS A COMMENT)
+```
 

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -24,17 +24,16 @@ You can also use existing plug-ins to capture contributions that are outside tho
 #### Use it if:
 - ✅ Your community lives on one or many of the supported platforms
 - ✅ Your community has strong leadership, emotional maturity and conflict resolution skills
-- ✅ The [trust level] of your community is high and/or the stakes are not significant 
+- ✅ The [trust level] of your community is high and/or the stakes are not significant
 - ✅ Your community is relatively small (i.e. not larger than [Dunbar's number](https://en.wikipedia.org/wiki/Dunbar%27s_number))
 - ✅ You're a fan of decentralized economies and changing the way we think about and distribute value
 
 #### Don't use it if:
 - ⛔️ You are looking for a silver bullet for community engagement/participation
 - ⛔️ You don't want to put time/effort into educating yourself and your community on how SourceCred works
-- ⛔️ You're looking for a production-ready, ultra-robust system that won't make breaking changes 
+- ⛔️ You're looking for a production-ready, ultra-robust system that won't make breaking changes
 
-[comment]: <> (WHAT DOES MAKE BREAKING CHANGES MEAN? CAN WE REPHRASE?)
-
+[//]: # (WHAT DOES MAKE BREAKING CHANGES MEAN? CAN WE REPHRASE?)
 
 ### How is SourceCred funded and how will it be sustainable long term?
 
@@ -42,7 +41,7 @@ SourceCred is not a corporation and has no investors. It is currently sponsored 
 
 SourceCred's model for sustainability comes from the communities/projects that use it flowing a portion of their Cred/Grain back to SourceCred as a "tribute". This allows SourceCred to be funded by its users, resulting in strong incentive alignments for everyone involved.
 
-[comment]: <> (THIS FAW SEEMS TO BE FOR DEVS INTERESTED IN USING SC, DO WE WANT TO INCLUDE MORE IN-DEPTH QUESTIONS ABOUT CRED/GRAIN?)
+[//]: # (THIS FAQ SEEMS TO BE FOR DEVS INTERESTED IN USING SC, DO WE WANT TO INCLUDE MORE IN-DEPTH QUESTIONS ABOUT CRED/GRAIN?)
 
 [Cred]: /docs/concepts/cred
 [Grain]: /docs/concepts/grain

--- a/docs/best-resources-for-new-contributors.md
+++ b/docs/best-resources-for-new-contributors.md
@@ -3,7 +3,7 @@ title: Best Resources for New Contributors
 description: The tools, guides and resources that are most relevant to people looking to start actively contributing to SourceCred.
 ---
 
-# Want to be part of the SoureCred team? 
+# Want to be part of the SoureCred team?
 
 First, try getting familiar with these helpful docs:
 
@@ -43,7 +43,7 @@ Here you'll find a spreadsheet with a link at the top. By clicking the link, you
 
 Throughout SourceCred's journey,  some interesting content has been created! You may enjoy looking through some of these noteworthy creations:
 
-[comment]: <> (UNSURE WHAT THESE ARE, WHERE TO FIND THEM, OR WHAT THEIR RELEVANCE IS)
+[//]: # (UNSURE WHAT THESE ARE, WHERE TO FIND THEM, OR WHAT THEIR RELEVANCE IS)
 * Evan's Explainer
 * Onboarding Philosophy
 * Champions vs Heros


### PR DESCRIPTION
Turns out the following comment syntax doesn't work with docasaurus:

> `[comment]: <> (This is a comment, it will not be included)`

Therefore we switch to:

> `[//]: # (This is a comment, it will not be included)`

This unbreaks the build. Yay!