### PR TITLE
Prevent PRs from getting closed instead of merged

### DIFF
--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -2,7 +2,7 @@ backend:
   name: github
   repo: sourcecred/docs
   branch: master
-  open_authoring: true # enables users without write access to author content from their forks
+  squash_merges: true
 publish_mode: editorial_workflow
 media_folder: "static/img/uploads"
 public_folder: "img/uploads"


### PR DESCRIPTION
Updated NetlifyCMS config to disable editorial workflow and squash-merge PRs