### PR TITLE
Small design tweaks to announcement bar

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -11,8 +11,8 @@ module.exports = {
       id: "winter_break_2021",
       content:
         'We will be taking radical rest from Dec 15 - Jan 17, and you might not hear back from us much. For info on how this affects Grain, etc, <a target="_blank" rel="noopener noreferrer" href="https://discourse.sourcecred.io/t/finalized-proposal-dec-jan-break-and-airdrop-2021/1306">click here</a>.',
-      backgroundColor: "#ff66ed",
-      textColor: "#091E42",
+      backgroundColor: "#ff7098",
+      textColor: "#28020d",
       isCloseable: false,
     },
     colorMode: {

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -50,3 +50,11 @@
   margin-left: auto;
   margin-right: auto;
 }
+
+/* CUSTOMIZATIONS TO THE ANNOUNCEMENT BANNER */
+div[class^='announcementBar']:not([class^='announcementBarContent']) {
+  min-height: 60px;
+  padding: 5px 10px;
+  align-items: center;
+  font-size: 18px;
+}


### PR DESCRIPTION
A few small tweaks to the announcement bar on the site so it fits a bit nicer with our branding and is a bit more legible.  Note that the bar does not stick to the top of the browser like the nav bar does, so the larger size shouldn't be an issue of taking up too much screen space. 

**View on desktop:**
![Screen Shot 2021-12-13 at 1 58 25 PM](https://user-images.githubusercontent.com/7217000/145895753-2c1deda2-9fc1-45fa-a78a-75340b2580ae.png)

**View on mobile:** 
![Screen Shot 2021-12-13 at 1 59 14 PM](https://user-images.githubusercontent.com/7217000/145895756-0615d329-8d54-470e-b108-efb7e03914ea.png)

